### PR TITLE
remove shap and xgboost as hard deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,4 @@ scipy
 statsmodels
 rasterstats
 quilt3
-shap
-xgboost
 libpysal


### PR DESCRIPTION
pip really struggles with xgboost, even when its already in the environment. This restores it as an optional dependency