### PR TITLE
add pysal integration/import test

### DIFF
--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -8,19 +8,27 @@ from numpy.testing import assert_almost_equal
 from tobler.dasymetric import glm, glm_pixel_adjusted, masked_area_interpolate
 from tobler.area_weighted import area_interpolate
 
-p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
-p["nlcd_2011.tif"].fetch()
 
 local_raster = os.getcwd() + "/nlcd_2011.tif"
 
-sac1 = load_example("Sacramento1")
-sac2 = load_example("Sacramento2")
 
-sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
-sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
+def datasets():
+
+    if not os.path.exists(local_raster):
+        p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
+        p["nlcd_2011.tif"].fetch()
+
+    sac1 = load_example("Sacramento1")
+    sac2 = load_example("Sacramento2")
+
+    sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+    sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
+
+    return sac1, sac2
 
 
 def test_area_interpolate():
+    sac1, sac2 = datasets()
     area = area_interpolate(
         source_df=sac2, target_df=sac1, extensive_variables=["POP2001"]
     )
@@ -28,6 +36,7 @@ def test_area_interpolate():
 
 
 def test_masked_area_interpolate():
+    sac1, sac2 = datasets()
     masked = masked_area_interpolate(
         source_df=sac2,
         target_df=sac1,
@@ -38,6 +47,7 @@ def test_masked_area_interpolate():
 
 
 def test_glm_pixel_adjusted():
+    sac1, sac2 = datasets()
     adjusted = glm_pixel_adjusted(
         source_df=sac2,
         target_df=sac1,
@@ -49,7 +59,7 @@ def test_glm_pixel_adjusted():
 
 
 def test_glm_poisson():
-
+    sac1, sac2 = datasets()
     glm_poisson = glm(
         source_df=sac2, target_df=sac1, variable="POP2001", raster=local_raster
     )

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -9,7 +9,7 @@ from tobler.dasymetric import glm, glm_pixel_adjusted, masked_area_interpolate
 from tobler.area_weighted import area_interpolate
 
 
-local_raster = os.getcwd() + "/nlcd_2011.tif"
+local_raster = os.path.join(os.getcwd(), "nlcd_2011.tif")    # portability
 
 
 def datasets():

--- a/tobler/tests/test_pysal_integration.py
+++ b/tobler/tests/test_pysal_integration.py
@@ -1,0 +1,7 @@
+"""lightweight test for pysal metapckage that functions import."""
+
+def test_imports():
+    import quilt3
+    from tobler.dasymetric import glm, glm_pixel_adjusted, masked_area_interpolate
+    from tobler.area_weighted import area_interpolate
+    from tobler.data import store_rasters


### PR DESCRIPTION
during pysal metapackage integration, we only need to test that the packages import, so this adds a simple test that does so.

this means we can skip the actual (long running) tests during pysal integration, as they are already run on the subpackages