### PR TITLE
Update installation.rst

### DIFF
--- a/docsrc/installation.rst
+++ b/docsrc/installation.rst
@@ -12,18 +12,30 @@ Installation
 tobler supports Python `3.6`_ and `3.7`_ only. Please make sure that you are
 operating in a Python 3 environment.
 
-Installing released version
----------------------------
-
-You can install tobler with :python:`pip install tobler`
-
-Installing development version
+Installing a released version
 ------------------------------
-The recommended method for installing tobler is with `anaconda`_. To get started with the development version, clone this repository or download it manually then ``cd`` into the directory and run the following commands::
+``tobler`` is available on both conda and pip, and can be installed with either
 
-$ conda env create -f environment.yml
-$ source activate tobler 
-$ python setup.py develop
+.. code-block:: bash
+
+    conda install -c conda-forge tobler
+
+or
+
+.. code-block:: bash
+
+    pip install tobler
+
+
+Installing a development from source
+-------------------------------------
+For working with a development version, we recommend `anaconda`_. To get started, clone this repository or download it manually then ``cd`` into the directory and run the following commands:
+
+.. code-block:: bash
+
+    conda env create -f environment.yml
+    source activate tobler 
+    python setup.py develop
 
 You can  also `fork`_ the `pysal/tobler`_ repo and create a local clone of
 your fork. By making changes

--- a/docsrc/installation.rst
+++ b/docsrc/installation.rst
@@ -9,8 +9,8 @@
 Installation
 ===============
 
-tobler supports python `3.5`_ and `3.6`_ only. Please make sure that you are
-operating in a python 3 environment.
+tobler supports Python `3.6`_ and `3.7`_ only. Please make sure that you are
+operating in a Python 3 environment.
 
 Installing released version
 ---------------------------
@@ -19,7 +19,7 @@ You can install tobler with :python:`pip install tobler`
 
 Installing development version
 ------------------------------
-The recommended method for installing tobler is with `anaconda`_. To get started with the development version, clone this repository or download it manually then `cd` into the directory and run the following commands::
+The recommended method for installing tobler is with `anaconda`_. To get started with the development version, clone this repository or download it manually then ``cd`` into the directory and run the following commands::
 
 $ conda env create -f environment.yml
 $ source activate tobler 
@@ -30,8 +30,8 @@ your fork. By making changes
 to your local clone and submitting a pull request to `pysal/tobler`_, you can
 contribute to the tobler development.
 
-.. _3.5: https://docs.python.org/3.5/
 .. _3.6: https://docs.python.org/3.6/
+.. _3.7: https://docs.python.org/3.7/
 .. _Python Package Index: https://pypi.org/pysal/tobler/
 .. _pysal/tobler: https://github.com/pysal/tobler
 .. _fork: https://help.github.com/articles/fork-a-repo/


### PR DESCRIPTION
This PR address the following:
  * Python 3.5/6 are mentioned in `installation`, but `tobler` supports 3.6/7.
  * minor formatting improvements.