### PR TITLE
allow specifying path for quilt storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
 
 script:
   - if [[ $TRAVIS_JOB_NAME == python-* ]]; then
+      python -c "import os; from tobler.data import store_rasters; store_rasters(os.getcwd())"; 
       travis_wait 45 pytest --cov tobler ;
     fi
 

--- a/tobler/data.py
+++ b/tobler/data.py
@@ -15,7 +15,7 @@ def store_rasters(dest=None):
         for use in interpolation functions from the `harmonize` module.
 
     """
-    quilt3.Package.install("rasters/nlcd", "s3://quilt-cgs", dest=dest)
+    quilt3.Package.install("rasters/nlcd", "s3://spatial-ucr", dest=dest)
 
 
 def fetch_quilt_path(path):

--- a/tobler/data.py
+++ b/tobler/data.py
@@ -50,7 +50,7 @@ def fetch_quilt_path(path):
         if parts.hostname:
             full_path = parts.scheme + "://" + parts.hostname + parts.path
         else:
-            full_path = parts.scheme + "://" + parts.path
+            full_path = parts.path
 
     else:
         return path

--- a/tobler/data.py
+++ b/tobler/data.py
@@ -5,7 +5,7 @@ from requests.exceptions import Timeout
 import quilt3
 
 
-def store_rasters():
+def store_rasters(dest=None):
     """Save raster data to the local quilt package storage.
 
     Returns
@@ -15,11 +15,11 @@ def store_rasters():
         for use in interpolation functions from the `harmonize` module.
 
     """
-    quilt3.Package.install("rasters/nlcd", "s3://quilt-cgs")
+    quilt3.Package.install("rasters/nlcd", "s3://quilt-cgs", dest=dest)
 
 
 def fetch_quilt_path(path):
-    """utility for getting the path to a raster stored with quilt.
+    """Get the path to a raster stored with quilt.
 
     Parameters
     ----------
@@ -35,13 +35,12 @@ def fetch_quilt_path(path):
         otherwise return the original path untouched
 
     """
-
     if path in ["nlcd_2011", "nlcd_2001"]:
         try:
             from quilt3.data.rasters import nlcd
 
         except ImportError:
-            raise(
+            raise IOError(
                 "Unable to locate local raster data. You can store NLCD rasters locally using "
                 "the `data.store_rasters()` function (python kernel restart required"
             )

--- a/tobler/tests/test_download.py
+++ b/tobler/tests/test_download.py
@@ -1,5 +1,5 @@
 from tobler.data import store_rasters
-
+import os
 
 def test_raster_download():
-    store_rasters()
+    store_rasters(os.getcwd())

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -16,13 +16,13 @@ def datasets():
         p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
         p["nlcd_2011.tif"].fetch()
 
-        sac1 = load_example("Sacramento1")
-        sac2 = load_example("Sacramento2")
+    sac1 = load_example("Sacramento1")
+    sac2 = load_example("Sacramento2")
 
-        sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
-        sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
+    sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+    sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
 
-        return sac1, sac2
+    return sac1, sac2
 
 
 def test_area_interpolate():

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -10,7 +10,7 @@ from tobler.area_weighted import area_interpolate
 from tobler.model import glm, glm_pixel_adjusted
 
 
-local_raster = os.path.join(os.getcwd(), "nlcd_2011.tif")    # portability
+#local_raster = os.path.join(os.getcwd(), "nlcd_2011.tif")    # portability
 
 
 def datasets():
@@ -42,7 +42,7 @@ def test_masked_area_interpolate():
         source_df=sac2,
         target_df=sac1,
         extensive_variables=["POP2001"],
-        raster=local_raster,
+        raster="nlcd_2011",
     )
     assert masked.POP2001.sum() > 1500000
 
@@ -54,7 +54,7 @@ def test_glm_pixel_adjusted():
         target_df=sac1,
         variable="POP2001",
         ReLU=False,
-        raster=local_raster,
+        raster="nlcd_2011",
     )
     assert_almost_equal(adjusted.POP2001.sum(), 4054516, decimal=0)
 
@@ -62,6 +62,6 @@ def test_glm_pixel_adjusted():
 def test_glm_poisson():
     sac1, sac2 = datasets()
     glm_poisson = glm(
-        source_df=sac2, target_df=sac1, variable="POP2001", raster=local_raster
+        source_df=sac2, target_df=sac1, variable="POP2001", raster="nlcd_2011"
     )
     assert glm_poisson.POP2001.sum() > 1469000

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -15,9 +15,9 @@ from tobler.model import glm, glm_pixel_adjusted
 
 def datasets():
 
-    if not os.path.exists(local_raster):
-        p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
-        p["nlcd_2011.tif"].fetch()
+  #  if not os.path.exists(local_raster):
+  #      p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
+  #      p["nlcd_2011.tif"].fetch()
 
     sac1 = load_example("Sacramento1")
     sac2 = load_example("Sacramento2")

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -13,7 +13,7 @@ from tobler.model import glm, glm_pixel_adjusted
 def datasets():
 
     if not os.path.exists("nlcd_2011.tif"):
-        p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
+        p = quilt3.Package.browse("rasters/nlcd", "s3://spatial-ucr")
         p["nlcd_2011.tif"].fetch()
 
     sac1 = load_example("Sacramento1")

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -10,22 +10,19 @@ from tobler.area_weighted import area_interpolate
 from tobler.model import glm, glm_pixel_adjusted
 
 
-#local_raster = os.path.join(os.getcwd(), "nlcd_2011.tif")    # portability
-
-
 def datasets():
 
-  #  if not os.path.exists(local_raster):
-  #      p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
-  #      p["nlcd_2011.tif"].fetch()
+    if not os.path.exists(local_raster):
+        p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
+        p["nlcd_2011.tif"].fetch()
 
-    sac1 = load_example("Sacramento1")
-    sac2 = load_example("Sacramento2")
+        sac1 = load_example("Sacramento1")
+        sac2 = load_example("Sacramento2")
 
-    sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
-    sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
+        sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+        sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
 
-    return sac1, sac2
+        return sac1, sac2
 
 
 def test_area_interpolate():
@@ -42,7 +39,7 @@ def test_masked_area_interpolate():
         source_df=sac2,
         target_df=sac1,
         extensive_variables=["POP2001"],
-        raster="nlcd_2011",
+        raster="nlcd_2011.tif",
     )
     assert masked.POP2001.sum() > 1500000
 
@@ -54,7 +51,7 @@ def test_glm_pixel_adjusted():
         target_df=sac1,
         variable="POP2001",
         ReLU=False,
-        raster="nlcd_2011",
+        raster="nlcd_2011.tif",
     )
     assert_almost_equal(adjusted.POP2001.sum(), 4054516, decimal=0)
 
@@ -62,6 +59,6 @@ def test_glm_pixel_adjusted():
 def test_glm_poisson():
     sac1, sac2 = datasets()
     glm_poisson = glm(
-        source_df=sac2, target_df=sac1, variable="POP2001", raster="nlcd_2011"
+        source_df=sac2, target_df=sac1, variable="POP2001", raster="nlcd_2011.tif"
     )
     assert glm_poisson.POP2001.sum() > 1469000

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -12,7 +12,7 @@ from tobler.model import glm, glm_pixel_adjusted
 
 def datasets():
 
-    if not os.path.exists(local_raster):
+    if not os.path.exists("nlcd_2011.tif"):
         p = quilt3.Package.browse("rasters/nlcd", "s3://quilt-cgs")
         p["nlcd_2011.tif"].fetch()
 

--- a/tools/gitcount.ipynb
+++ b/tools/gitcount.ipynb
@@ -155,7 +155,7 @@
     {
      "data": {
       "text/plain": [
-       "25"
+       "21"
       ]
      },
      "execution_count": 8,
@@ -254,7 +254,7 @@
     {
      "data": {
       "text/plain": [
-       "dict_keys(['Eli Knaap', 'James Gaboardi', 'Serge Rey'])"
+       "dict_keys(['Eli Knaap', 'James Gaboardi'])"
       ]
      },
      "execution_count": 14,
@@ -434,7 +434,9 @@
     {
      "data": {
       "text/plain": [
-       "['quilt handling (#52)',\n",
+       "['reorg: adding model submodule (#55)',\n",
+       " 'bump version for bugfix release (#53)',\n",
+       " 'quilt handling (#52)',\n",
        " 'Merge pull request #48 from knaaptime/master (#48)',\n",
        " 'Merge pull request #47 from jGaboardi/update_docs (#47)',\n",
        " 'Update installation.rst (#46)',\n",
@@ -477,7 +479,7 @@
     {
      "data": {
       "text/plain": [
-       "'We closed a total of 12 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-05.'"
+       "'We closed a total of 16 issues (enhancements and bug fixes) through 8 pull requests, since our last release on 2020-01-05.'"
       ]
      },
      "execution_count": 23,
@@ -507,7 +509,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We closed a total of 12 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-05.\n",
+      "We closed a total of 16 issues (enhancements and bug fixes) through 8 pull requests, since our last release on 2020-01-05.\n",
       "\n",
       "## Issues Closed\n",
       "\n"
@@ -540,9 +542,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We closed a total of 12 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-05.\n",
+      "We closed a total of 16 issues (enhancements and bug fixes) through 8 pull requests, since our last release on 2020-01-05.\n",
       "\n",
       "## Issues Closed\n",
+      "  - reorg: adding model submodule (#55)\n",
+      "  - bump version for bugfix release (#53)\n",
       "  - quilt handling (#52)\n",
       "  - Merge pull request #48 from knaaptime/master (#48)\n",
       "  - Merge pull request #47 from jGaboardi/update_docs (#47)\n",
@@ -551,6 +555,8 @@
       "  - add pysal integration/import test (#44)\n",
       "\n",
       "## Pull Requests\n",
+      "  - reorg: adding model submodule (#55)\n",
+      "  - bump version for bugfix release (#53)\n",
       "  - quilt handling (#52)\n",
       "  - Merge pull request #48 from knaaptime/master (#48)\n",
       "  - Merge pull request #47 from jGaboardi/update_docs (#47)\n",
@@ -583,8 +589,7 @@
      "output_type": "stream",
      "text": [
       "  - Eli Knaap\n",
-      "  - James Gaboardi\n",
-      "  - Serge Rey\n"
+      "  - James Gaboardi\n"
      ]
     }
    ],
@@ -610,9 +615,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "We closed a total of 12 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-05.\n",
+      "We closed a total of 16 issues (enhancements and bug fixes) through 8 pull requests, since our last release on 2020-01-05.\n",
       "\n",
       "## Issues Closed\n",
+      "  - reorg: adding model submodule (#55)\n",
+      "  - bump version for bugfix release (#53)\n",
       "  - quilt handling (#52)\n",
       "  - Merge pull request #48 from knaaptime/master (#48)\n",
       "  - Merge pull request #47 from jGaboardi/update_docs (#47)\n",
@@ -621,6 +628,8 @@
       "  - add pysal integration/import test (#44)\n",
       "\n",
       "## Pull Requests\n",
+      "  - reorg: adding model submodule (#55)\n",
+      "  - bump version for bugfix release (#53)\n",
       "  - quilt handling (#52)\n",
       "  - Merge pull request #48 from knaaptime/master (#48)\n",
       "  - Merge pull request #47 from jGaboardi/update_docs (#47)\n",
@@ -631,8 +640,7 @@
       "The following individuals contributed to this release:\n",
       "\n",
       "  - Eli Knaap\n",
-      "  - James Gaboardi\n",
-      "  - Serge Rey\n"
+      "  - James Gaboardi\n"
      ]
     }
    ],
@@ -662,9 +670,11 @@
       "\n",
       "Version 0.2.1 (2020-02-21)\n",
       "\n",
-      "We closed a total of 12 issues (enhancements and bug fixes) through 6 pull requests, since our last release on 2020-01-05.\n",
+      "We closed a total of 16 issues (enhancements and bug fixes) through 8 pull requests, since our last release on 2020-01-05.\n",
       "\n",
       "## Issues Closed\n",
+      "  - reorg: adding model submodule (#55)\n",
+      "  - bump version for bugfix release (#53)\n",
       "  - quilt handling (#52)\n",
       "  - Merge pull request #48 from knaaptime/master (#48)\n",
       "  - Merge pull request #47 from jGaboardi/update_docs (#47)\n",
@@ -673,6 +683,8 @@
       "  - add pysal integration/import test (#44)\n",
       "\n",
       "## Pull Requests\n",
+      "  - reorg: adding model submodule (#55)\n",
+      "  - bump version for bugfix release (#53)\n",
       "  - quilt handling (#52)\n",
       "  - Merge pull request #48 from knaaptime/master (#48)\n",
       "  - Merge pull request #47 from jGaboardi/update_docs (#47)\n",
@@ -683,8 +695,7 @@
       "The following individuals contributed to this release:\n",
       "\n",
       "  - Eli Knaap\n",
-      "  - James Gaboardi\n",
-      "  - Serge Rey\n"
+      "  - James Gaboardi\n"
      ]
     }
    ],


### PR DESCRIPTION
the default storage path works fine for most applications but fails on travis. This allows a user to specify a download location where the quilt package, which should make it easier to solve issues like these https://travis-ci.org/knaaptime/geosnap/jobs/653970124?utm_medium=notification&utm_source=email