### PR TITLE
[TST] conditionally skip 3.8 tests needing quilt

### DIFF
--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -16,7 +16,6 @@ dependencies:
   - libpysal
   - tqdm
   - codecov
-  - quilt3
   - pytest
   - pytest-mpl
   - pytest-cov

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -1,30 +1,40 @@
 """test interpolation functions."""
+import sys
 import pandas as pd
 import geopandas
-import quilt3
+try:
+    import quilt3
+    QUILTMISSING = False
+except ImportError:
+    QUILTMISSING = True
+
 import os
 from libpysal.examples import load_example
 from numpy.testing import assert_almost_equal
 from tobler.dasymetric import masked_area_interpolate
 from tobler.area_weighted import area_interpolate
 from tobler.model import glm, glm_pixel_adjusted
+import pytest
 
 
 def datasets():
+    if not QUILTMISSING:
 
-    if not os.path.exists("nlcd_2011.tif"):
-        p = quilt3.Package.browse("rasters/nlcd", "s3://spatial-ucr")
-        p["nlcd_2011.tif"].fetch()
+        if not os.path.exists("nlcd_2011.tif"):
+            p = quilt3.Package.browse("rasters/nlcd", "s3://spatial-ucr")
+            p["nlcd_2011.tif"].fetch()
 
-    sac1 = load_example("Sacramento1")
-    sac2 = load_example("Sacramento2")
+        sac1 = load_example("Sacramento1")
+        sac2 = load_example("Sacramento2")
 
-    sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
-    sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
+        sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+        sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
 
-    return sac1, sac2
+        return sac1, sac2
+    else:
+        pass
 
-
+@pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
 def test_area_interpolate():
     sac1, sac2 = datasets()
     area = area_interpolate(
@@ -33,6 +43,7 @@ def test_area_interpolate():
     assert_almost_equal(area.POP2001.sum(), 1894018, decimal=0)
 
 
+@pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
 def test_masked_area_interpolate():
     sac1, sac2 = datasets()
     masked = masked_area_interpolate(
@@ -44,6 +55,7 @@ def test_masked_area_interpolate():
     assert masked.POP2001.sum() > 1500000
 
 
+@pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
 def test_glm_pixel_adjusted():
     sac1, sac2 = datasets()
     adjusted = glm_pixel_adjusted(
@@ -56,6 +68,7 @@ def test_glm_pixel_adjusted():
     assert_almost_equal(adjusted.POP2001.sum(), 4054516, decimal=0)
 
 
+@pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
 def test_glm_poisson():
     sac1, sac2 = datasets()
     glm_poisson = glm(


### PR DESCRIPTION
It looks like quilt is not available for 3.8 on conda-forge:

![image](https://user-images.githubusercontent.com/118042/87256762-4c015080-c44a-11ea-844d-49ff4af87808.png)


So, I think that is why the ci couldn't solve for the testing env.

This PR starts some conditional skipping if quilt isn't available.

Looks to be [working](https://github.com/sjsrey/tobler/runs/863412852?check_suite_focus=true)

## To do

- [ ] add warnings that quilt isn't available
- [ ] update docs