### PR TITLE
REF: use STRtree.query_bulk in _area_tables_binning

### DIFF
--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -22,3 +22,4 @@ dependencies:
   - pytest-cov
   - twine
   - pip
+  - pygeos

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -22,3 +22,4 @@ dependencies:
   - pytest-cov
   - twine
   - pip
+  - pygeos

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -22,3 +22,4 @@ dependencies:
   - pytest-cov
   - twine
   - pip
+  - pygeos

--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
   - libpysal
   - tqdm
   - pip
+  - pygeos

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ statsmodels
 rasterstats
 libpysal
 tqdm
+pygeos

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -16,3 +16,4 @@ twine
 xgboost
 shap >=0.33
 quilt3 >=3.1.11
+pygeos

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -1,41 +1,82 @@
 """test interpolation functions."""
 import geopandas
-try:
-    import quilt3
-    QUILTMISSING = False
-except ImportError:
-    QUILTMISSING = True
 
-import os
 from libpysal.examples import load_example
 from numpy.testing import assert_almost_equal
 from tobler.area_weighted import area_interpolate
+from tobler.area_weighted.area_interpolate import _area_tables_binning
+from geopandas.testing import assert_geodataframe_equal
 import pytest
 
 
 def datasets():
-    if not QUILTMISSING:
+    sac1 = load_example("Sacramento1")
+    sac2 = load_example("Sacramento2")
+    sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+    sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
+    sac1["pct_poverty"] = sac1.POV_POP / sac1.POV_TOT
 
-        if not os.path.exists("nlcd_2011.tif"):
-            p = quilt3.Package.browse("rasters/nlcd", "s3://spatial-ucr")
-            p["nlcd_2011.tif"].fetch()
-        sac1 = load_example('Sacramento1')
-        sac2 = load_example('Sacramento2')
-        sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
-        sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
-        sac1['pct_poverty'] = sac1.POV_POP/sac1.POV_TOT
-
-        return sac1, sac2
-    else:
-        pass
+    return sac1, sac2
 
 
-@pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
 def test_area_interpolate():
     sac1, sac2 = datasets()
     area = area_interpolate(
-        source_df=sac1, target_df=sac2, extensive_variables=["TOT_POP"],
-        intensive_variables=["pct_poverty"]
+        source_df=sac1,
+        target_df=sac2,
+        extensive_variables=["TOT_POP"],
+        intensive_variables=["pct_poverty"],
     )
     assert_almost_equal(area.TOT_POP.sum(), 1796856, decimal=0)
     assert_almost_equal(area.pct_poverty.sum(), 2140, decimal=0)
+
+
+def test_area_interpolate_sindex_options():
+    sac1, sac2 = datasets()
+    auto = area_interpolate(
+        source_df=sac1,
+        target_df=sac2,
+        extensive_variables=["TOT_POP"],
+        intensive_variables=["pct_poverty"],
+    )
+    source = area_interpolate(
+        source_df=sac1,
+        target_df=sac2,
+        extensive_variables=["TOT_POP"],
+        intensive_variables=["pct_poverty"],
+        spatial_index="source",
+    )
+    target = area_interpolate(
+        source_df=sac1,
+        target_df=sac2,
+        extensive_variables=["TOT_POP"],
+        intensive_variables=["pct_poverty"],
+        spatial_index="target",
+    )
+
+    assert_geodataframe_equal(auto, source)
+    assert_geodataframe_equal(auto, target)
+
+    with pytest.raises(ValueError):
+        area_interpolate(
+            source_df=sac1,
+            target_df=sac2,
+            extensive_variables=["TOT_POP"],
+            intensive_variables=["pct_poverty"],
+            spatial_index="non-existent",
+        )
+
+
+def test_area_tables_binning():
+    sac1, sac2 = datasets()
+
+    auto = _area_tables_binning(source_df=sac1, target_df=sac2, spatial_index="auto")
+    source = _area_tables_binning(
+        source_df=sac1, target_df=sac2, spatial_index="source"
+    )
+    target = _area_tables_binning(
+        source_df=sac1, target_df=sac2, spatial_index="target"
+    )
+
+    assert (auto != source).sum() == 0
+    assert (auto != target).sum() == 0

--- a/tobler/tests/test_interpolators.py
+++ b/tobler/tests/test_interpolators.py
@@ -80,3 +80,8 @@ def test_area_tables_binning():
 
     assert (auto != source).sum() == 0
     assert (auto != target).sum() == 0
+
+    assert auto.sum() == pytest.approx(1.3879647)
+    assert auto.mean() == pytest.approx(2.7552649e-05)
+
+    assert (auto[5][0].toarray() > 0).sum() == 7


### PR DESCRIPTION
xref #104 

This is the latest version of single-core refactoring of `area_interpolate`. It turned out, that using pygeos-backed `STRtree` and its vectorized `query_bulk` in geopandas is even faster than the numba version @darribas mentioned in #104.

While pygeos is not strictly necessary and geopandas can use `rtree` for this operation, pygeos will bring speedup of the order of magnitude so I am adding it to requirements to make sure user have it installed.