### PR TITLE
ENH: add area_join for join based on the largest intersection

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,7 +9,7 @@ API reference
 
 Area Weighted
 --------------
-Area weighted approaches use the area of overlap between the source and target geometries to weight the 
+Area weighted approaches use the area of overlap between the source and target geometries to weight the
 variables being assigned to the target
 
 .. currentmodule:: tobler.area_weighted
@@ -18,12 +18,13 @@ variables being assigned to the target
    :toctree: generated/
 
     area_interpolate
+    area_join
 
 
 Dasymetric
 -----------------------
 
-Dasymetric approaches use auxiliary data in addition to use the area of overlap between the source and target geometries to weight the 
+Dasymetric approaches use auxiliary data in addition to use the area of overlap between the source and target geometries to weight the
 variables being assigned to the target
 
 .. currentmodule:: tobler.dasymetric

--- a/tobler/area_weighted/__init__.py
+++ b/tobler/area_weighted/__init__.py
@@ -2,4 +2,4 @@ from .area_interpolate import _area_interpolate_binning as area_interpolate
 from .area_interpolate import _area_interpolate as _slow_area_interpolate
 from .area_interpolate import _area_tables, _area_tables_binning, _area_tables_raster
 from .area_interpolate import _check_presence_of_crs
-from .max_area import area_max
+from .area_join import area_join

--- a/tobler/area_weighted/__init__.py
+++ b/tobler/area_weighted/__init__.py
@@ -2,3 +2,4 @@ from .area_interpolate import _area_interpolate_binning as area_interpolate
 from .area_interpolate import _area_interpolate as _slow_area_interpolate
 from .area_interpolate import _area_tables, _area_tables_binning, _area_tables_raster
 from .area_interpolate import _check_presence_of_crs
+from .max_area import area_max

--- a/tobler/area_weighted/max_area.py
+++ b/tobler/area_weighted/max_area.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+import warnings
+
+__author__ = "Martin Fleischmann <martin@martinfleischmann.net>"
+
+
+def area_max(source_df, target_df, variables):
+    """
+    Join attributes from source based on the largest intersection. In case of a tie it picks the first one.
+
+    Parameters
+    ----------
+    source_df : GeoDataFrame
+        GeoDataFrame containing source values
+    target_df : GeoDataFrame
+        GeoDataFrame containing source values
+    variables : string or list-like
+        column(s) in dataframes for variable(s)
+
+    Returns
+    -------
+    GeoDataFrame
+
+    """
+    target_df = target_df.copy()
+    target_ix, source_ix = source_df.sindex.query_bulk(
+        target_df.geometry, predicate="intersects"
+    )
+    areas = (
+        target_df.geometry.values[target_ix]
+        .intersection(source_df.geometry.values[source_ix])
+        .area
+    )
+
+    main = []
+    for i in range(len(target_df)):
+        mask = target_ix == i
+        if np.any(mask):
+            main.append(source_ix[mask][np.argmax(areas[mask])])
+        else:
+            main.append(np.nan)
+
+    main = np.array(main, dtype=float)
+    mask = ~np.isnan(main)
+
+    if not pd.api.types.is_list_like(variables):
+        variables = [variables]
+
+    for v in variables:
+        arr = np.empty(len(main), dtype=object)
+        arr[mask] = source_df[v].values[main[mask].astype(int)]
+        try:
+            arr = arr.astype(source_df[v].dtype)
+        except TypeError:
+            warnings.warn(
+                f"Cannot preserve dtype of '{v}'. Falling back to `dtype=object`.",
+            )
+        target_df[v] = arr
+
+    return target_df

--- a/tobler/tests/test_area_join.py
+++ b/tobler/tests/test_area_join.py
@@ -1,0 +1,70 @@
+import geopandas as gpd
+import numpy as np
+from shapely.geometry import Point
+
+import pytest
+
+from tobler.area_weighted import area_join
+
+
+class TestAreaJoin:
+    def setup_method(self):
+        self.grid = gpd.points_from_xy(
+            np.repeat(np.linspace(1, 10, 10), 10), np.tile(np.linspace(1, 10, 10), 10)
+        ).buffer(0.5, cap_style=3)
+        self.source = gpd.GeoDataFrame(
+            {
+                "floats": np.linspace(1, 10, 100),
+                "ints": np.linspace(1, 100, 100, dtype="int"),
+                "strings": np.array(["darribas", "is", "the", "king"] * 25),
+            },
+            geometry=self.grid,
+        )
+
+        self.target = gpd.GeoDataFrame(geometry=self.grid.translate(xoff=2.2, yoff=0.2))
+
+    def test_area_join_float(self):
+        result = area_join(self.source, self.target, "floats")
+        assert (result.columns == ["geometry", "floats"]).all()
+        np.testing.assert_almost_equal(result.floats.mean(), 6.409, 3)
+        assert result.floats.dtype == float
+        assert result.floats.isna().sum() == 20
+
+    def test_area_join_ints(self):
+        with pytest.warns(UserWarning, match="Cannot preserve dtype of"):
+            result = area_join(self.source, self.target, "ints")
+
+        assert (result.columns == ["geometry", "ints"]).all()
+        np.testing.assert_almost_equal(result.ints.mean(), 60.5, 3)
+        assert result.ints.dtype == object
+        assert type(result.ints.iloc[0]) == int
+        assert result.ints.isna().sum() == 20
+
+    def test_area_join_strings(self):
+        result = area_join(self.source, self.target, "strings")
+        assert (result.columns == ["geometry", "strings"]).all()
+        assert result.strings.dtype == object
+        assert type(result.strings.iloc[0]) == str
+        assert result.strings.isna().sum() == 20
+
+    def test_area_join_array(self):
+        with pytest.warns(UserWarning, match="Cannot preserve dtype of"):
+            result = area_join(self.source, self.target, ["floats", "ints", "strings"])
+
+        assert (result.columns == ["geometry", "floats", "ints", "strings"]).all()
+        np.testing.assert_almost_equal(result.floats.mean(), 6.409, 3)
+        assert result.floats.dtype == float
+        assert result.floats.isna().sum() == 20
+        np.testing.assert_almost_equal(result.ints.mean(), 60.5, 3)
+        assert result.ints.dtype == object
+        assert type(result.ints.iloc[0]) == int
+        assert result.ints.isna().sum() == 20
+        assert result.strings.dtype == object
+        assert type(result.strings.iloc[0]) == str
+        assert result.strings.isna().sum() == 20
+
+    def test_area_join_error(self):
+        target = self.target
+        target["floats"] = 0
+        with pytest.raises(ValueError, match="Column 'floats'"):
+            area_join(self.source, target, "floats")

--- a/tobler/tests/test_dasymetric.py
+++ b/tobler/tests/test_dasymetric.py
@@ -2,8 +2,10 @@
 import sys
 import pandas as pd
 import geopandas
+
 try:
     import quilt3
+
     QUILTMISSING = False
 except ImportError:
     QUILTMISSING = True
@@ -23,25 +25,28 @@ def datasets():
         if not os.path.exists("nlcd_2011.tif"):
             p = quilt3.Package.browse("rasters/nlcd", "s3://spatial-ucr")
             p["nlcd_2011.tif"].fetch()
-        sac1 = load_example('Sacramento1')
-        sac2 = load_example('Sacramento2')
+        sac1 = load_example("Sacramento1")
+        sac2 = load_example("Sacramento2")
         sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
         sac2 = geopandas.read_file(sac2.get_path("SacramentoMSA2.shp"))
-        sac1['pct_poverty'] = sac1.POV_POP/sac1.POV_TOT
+        sac1["pct_poverty"] = sac1.POV_POP / sac1.POV_TOT
 
         return sac1, sac2
     else:
         pass
 
+
 @pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
 def test_area_interpolate():
     sac1, sac2 = datasets()
     area = area_interpolate(
-        source_df=sac1, target_df=sac2, extensive_variables=["TOT_POP"], intensive_variables=["pct_poverty"]
+        source_df=sac1,
+        target_df=sac2,
+        extensive_variables=["TOT_POP"],
+        intensive_variables=["pct_poverty"],
     )
     assert_almost_equal(area.TOT_POP.sum(), 1796856, decimal=0)
     assert_almost_equal(area.pct_poverty.sum(), 2140, decimal=0)
-
 
 
 @pytest.mark.skipif(QUILTMISSING, reason="quilt3 not available.")
@@ -51,7 +56,7 @@ def test_masked_area_interpolate():
         source_df=sac1,
         target_df=sac2,
         extensive_variables=["TOT_POP"],
-        intensive_variables=['pct_poverty'],
+        intensive_variables=["pct_poverty"],
         raster="nlcd_2011.tif",
     )
     assert masked.TOT_POP.sum() > 1500000
@@ -78,3 +83,17 @@ def test_glm_poisson():
         source_df=sac2, target_df=sac1, variable="POP2001", raster="nlcd_2011.tif"
     )
     assert glm_poisson.POP2001.sum() > 1469000
+
+
+# grid = gpd.points_from_xy(
+#     np.repeat(np.linspace(1, 10, 10), 10), np.tile(np.linspace(1, 10, 10), 10)
+# ).buffer(0.5, cap_style=3)
+# source = gpd.GeoDataFrame(
+#     {
+#         "floats": np.linspace(1, 10, 100),
+#         "ints": np.linspace(1, 100, 100, dtype="int"),
+#         "strings": np.array(["darribas", "is", "the", "king"] * 25),
+#     },
+#     geometry=grid,
+# )
+# target = gpd.GeoDataFrame(geometry=grid.translate(xoff=2.2, yoff=0.2))

--- a/tobler/tests/test_dasymetric.py
+++ b/tobler/tests/test_dasymetric.py
@@ -83,17 +83,3 @@ def test_glm_poisson():
         source_df=sac2, target_df=sac1, variable="POP2001", raster="nlcd_2011.tif"
     )
     assert glm_poisson.POP2001.sum() > 1469000
-
-
-# grid = gpd.points_from_xy(
-#     np.repeat(np.linspace(1, 10, 10), 10), np.tile(np.linspace(1, 10, 10), 10)
-# ).buffer(0.5, cap_style=3)
-# source = gpd.GeoDataFrame(
-#     {
-#         "floats": np.linspace(1, 10, 100),
-#         "ints": np.linspace(1, 100, 100, dtype="int"),
-#         "strings": np.array(["darribas", "is", "the", "king"] * 25),
-#     },
-#     geometry=grid,
-# )
-# target = gpd.GeoDataFrame(geometry=grid.translate(xoff=2.2, yoff=0.2))


### PR DESCRIPTION
Closes #101

I am open to suggestions on the name and the placement of the function within tobler.

If there is no match for some rows in `target_df`, some column dtpyes (integer is not nullable) are not preserved and fall back to `object`.

Where to put an example? To the existing notebook or to a new one? And what is the relationship between those in `notebooks` and those in `docs/notebooks`, are they just duplicated?