### PR TITLE
hexify multipolygons

### DIFF
--- a/tobler/tests/test_utils.py
+++ b/tobler/tests/test_utils.py
@@ -33,3 +33,10 @@ def test_h3fy_clip():
     assert_almost_equal(
         sac_hex.to_crs(32710).unary_union.area, 13131736346.537416, decimal=4
     )
+
+def test_h3_multipoly():
+    va = geopandas.read_file(load_example('virginia').get_path('virginia.shp'))
+    va = h3fy(va)
+    assert_almost_equal(
+        va.to_crs(2284).unary_union.area, 1106844905155.1118, decimal=4
+    )

--- a/tobler/tests/test_utils.py
+++ b/tobler/tests/test_utils.py
@@ -38,5 +38,5 @@ def test_h3_multipoly():
     va = geopandas.read_file(load_example('virginia').get_path('virginia.shp'))
     va = h3fy(va)
     assert_almost_equal(
-        va.to_crs(2284).unary_union.area, 1106844905155.1118, decimal=4
+        va.to_crs(2284).unary_union.area, 1106844905155.1118, decimal=0
     )


### PR DESCRIPTION
#125  is resolved by first exploding the input, then handling via split-apply-combine if the resulting unary_union is a multipolygon itself