### PR TITLE
integrate smaup into tobler

### DIFF
--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -25,3 +25,4 @@ dependencies:
   - pygeos
   - h3-py
   - joblib
+  - esda

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -25,3 +25,4 @@ dependencies:
   - pygeos
   - h3-py
   - joblib
+  - esda

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -30,3 +30,4 @@ dependencies:
   - numpydoc
   - nbsphinx
   - joblib
+  - esda

--- a/environment.yml
+++ b/environment.yml
@@ -19,3 +19,4 @@ dependencies:
   - mapclassify 
   - descartes
   - joblib
+  - esda

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ libpysal
 tqdm
 pygeos
 joblib
+esda

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -16,3 +16,4 @@ twine
 xgboost
 shap >=0.33
 quilt3 >=3.1.11
+esda

--- a/tobler/__init__.py
+++ b/tobler/__init__.py
@@ -8,3 +8,4 @@ from . import area_weighted
 from . import dasymetric
 from . import model
 from . import util
+from . import diagnostics

--- a/tobler/area_weighted/area_interpolate.py
+++ b/tobler/area_weighted/area_interpolate.py
@@ -356,7 +356,7 @@ def _area_interpolate_binning(
     target_df = target_df.copy()
 
     if smaup_kwds is not None:
-        for var in intensive_variables,extensive_variables:
+        for var in intensive_variables:
             stat = _smaup(smaup_kwds["k"], source_df[var].to_numpy(), smaup_kwds["w"])
             if stat.summary.find('H0 is rejected'):
                 warn(f"{var} is affected by the MAUP. Interpolations of this variable may not be accourate!")

--- a/tobler/dasymetric/masked_area_interpolate.py
+++ b/tobler/dasymetric/masked_area_interpolate.py
@@ -63,7 +63,7 @@ def masked_area_interpolate(
         )
 
     if smaup_kwds is not None:
-        for var in intensive_variables,extensive_variables:
+        for var in intensive_variables:
             stat = _smaup(smaup_kwds["k"], source_df[var].to_numpy(), smaup_kwds["w"])
             if stat.summary.find('H0 is rejected'):
                 warn(f"{var} is affected by the MAUP. Interpolations of this variable may not be accourate!")

--- a/tobler/diagnostics/__init__.py
+++ b/tobler/diagnostics/__init__.py
@@ -1,0 +1,1 @@
+from .smaup import _smaup

--- a/tobler/diagnostics/smaup.py
+++ b/tobler/diagnostics/smaup.py
@@ -1,0 +1,35 @@
+"""
+A wrapper for using the S-maup statistical test in tobler interpolation
+
+"""
+
+from esda.smaup import Smaup
+from esda.moran import Moran
+
+def _smaup(k, y, w,):
+    """
+    A function that wraps esda's smaup function and automates some of the process of calculating smaup.
+    For more about smaup read here: https://pysal.org/esda/generated/esda.Smaup.html#esda.Smaup
+
+    Parameters
+    ----------
+
+    k               : int
+                      number of regions
+    y               : array
+                      data for autocorellation calculation
+    w               : libpysal.weights object
+                      pysal spatial weights object for autocorellation calculation
+
+    Returns
+    -------
+    esda.smaup.Smaup:
+        statistic that contains information regarding the extent to which the variable is affected by the MAUP.
+
+
+    """
+    rho = Moran(y, w).I
+    n = len(y)
+    stat = Smaup(n,k,rho)
+    return stat
+    

--- a/tobler/diagnostics/smaup.py
+++ b/tobler/diagnostics/smaup.py
@@ -5,31 +5,41 @@ A wrapper for using the S-maup statistical test in tobler interpolation
 
 from esda.smaup import Smaup
 from esda.moran import Moran
+from libpysal.weights import Rook
+from warnings import warn
 
-def _smaup(k, y, w,):
+def _smaup(
+    source_df,
+    target_df,
+    y,
+    w=None):
     """
     A function that wraps esda's smaup function and automates some of the process of calculating smaup.
     For more about smaup read here: https://pysal.org/esda/generated/esda.Smaup.html#esda.Smaup
 
     Parameters
     ----------
-
-    k               : int
-                      number of regions
+    source_df :     geopandas.GeoDataFrame
+                    source data to be converted. Used to construct spatial weights.
+    target_df :     geopandas.GeoDataFrame
+                    target geometries that will form the new representation of the input data. Used for k.
     y               : array
                       data for autocorellation calculation
     w               : libpysal.weights object
-                      pysal spatial weights object for autocorellation calculation
+                      pysal spatial weights object for autocorellation calculation.
+                      Rook recommended for smaup and used by default.
 
     Returns
     -------
     esda.smaup.Smaup:
         statistic that contains information regarding the extent to which the variable is affected by the MAUP.
 
-
     """
+    if w is None:
+        w = Rook.from_dataframe(source_df)
     rho = Moran(y, w).I
     n = len(y)
+    k = len(target_df)
     stat = Smaup(n,k,rho)
+
     return stat
-    

--- a/tobler/model/glm.py
+++ b/tobler/model/glm.py
@@ -150,7 +150,7 @@ def glm(
     _check_presence_of_crs(source_df)
 
     if smaup_weight is not None:
-        for var in intensive_variables:
+        for var in variable:
             stat = _smaup(
                 source_df=source_df,
                 target_df=target_df,
@@ -161,7 +161,7 @@ def glm(
             else:
                 print(f"{var} is not affected by the MAUP.")
     else:
-        for var in intensive_variables:
+        for var in variable:
             stat = _smaup(
                 source_df=source_df,
                 target_df=target_df,

--- a/tobler/tests/test_diagnostics.py
+++ b/tobler/tests/test_diagnostics.py
@@ -1,0 +1,13 @@
+"""test diagnostics funtions"""
+
+import geopandas
+from tobler.diagnostics import _smaup
+from libpysal.weights import Queen
+
+sac1 = load_example("Sacramento1")
+sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+
+def test_smaup():
+    queen = Queen.from_dataframe(sac1)
+    s = _smaup(1,sac1["pct_poverty"].to_numpy(),queen)
+    assert s.summary

--- a/tobler/tests/test_diagnostics.py
+++ b/tobler/tests/test_diagnostics.py
@@ -3,6 +3,8 @@
 import geopandas
 from tobler.diagnostics import _smaup
 from libpysal.weights import Queen
+from libpysal.examples import load_example
+
 
 sac1 = load_example("Sacramento1")
 sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))

--- a/tobler/tests/test_diagnostics.py
+++ b/tobler/tests/test_diagnostics.py
@@ -2,16 +2,15 @@
 
 import geopandas
 from tobler.diagnostics import _smaup
-from libpysal.weights import Queen
-from libpysal.examples import load_example
 
-
-sac1 = load_example("Sacramento1")
-sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
-sac1["pct_poverty"] = sac1.POV_POP / sac1.POV_TOT
-
+precincts = geopandas.read_file("https://ndownloader.figshare.com/files/20460549") 
+tracts = geopandas.read_file("https://ndownloader.figshare.com/files/20460645") 
 
 def test_smaup():
-    queen = Queen.from_dataframe(sac1)
-    s = _smaup(1,sac1["pct_poverty"].to_numpy(),queen)
-    assert s.summary
+    s = _smaup(
+        source_df=tracts,
+        target_df=precincts,
+        y=tracts["pct Youth"].to_numpy()
+    )
+    assert type(s.summary) == str
+    assert s.summary.find('H0 is rejected')

--- a/tobler/tests/test_diagnostics.py
+++ b/tobler/tests/test_diagnostics.py
@@ -8,6 +8,8 @@ from libpysal.examples import load_example
 
 sac1 = load_example("Sacramento1")
 sac1 = geopandas.read_file(sac1.get_path("sacramentot2.shp"))
+sac1["pct_poverty"] = sac1.POV_POP / sac1.POV_TOT
+
 
 def test_smaup():
     queen = Queen.from_dataframe(sac1)


### PR DESCRIPTION
- wrapper function over `esda` smaup
- just tell user whether or not variable is affected by MAUP, if they want more info they should run it themselves for now
- allow user to pass own regions and weights object in `smaup_kwds`
- begin `diagnostics` module
- only import warn from warnings

Addresses #51 and partially #84

This implementation does not automatically run `smaup`. It requires that the user pass their own weights object to calculate Moran's I, and choose the number of regions that they will be running `smaup` against. It also does not prioritize user interaction with the statistic (I suppose you could import the wrapper function itself and run it), it only tells the user whether the variable being used is affected by the MAUP.
![image](https://user-images.githubusercontent.com/64164151/113062947-12bd6c00-91a4-11eb-8f56-353d94900c2b.png)

Let me know what you think