### PR TITLE
CI: schedule weekly tests

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,55 +1,57 @@
- name: Unit Tests
- on:
-   push:
-     branches:
-     - '*'
-   pull_request:
-     branches:
-     - '*'
+name: Unit Tests
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "0 0 * * 0"
 
- jobs:
-   unittests:
-     name: CI (${{ matrix.os }}-${{ matrix.environment-file }})
-     runs-on: ${{ matrix.os }}
-     continue-on-error: ${{ matrix.experimental }}
-     timeout-minutes: 90
-     strategy:
-       matrix:
-         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-         environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml]
-         experimental: [false]
-     defaults:
-       run:
-         shell: bash -l {0}
-     steps:
-       - uses: actions/checkout@v2
-       - uses: actions/cache@v2
-         env:
-           CACHE_NUMBER: 0
-         with:
-           path: ~/conda_pkgs_dir
-           key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
-       - uses: conda-incubator/setup-miniconda@v2
-         with:
-            miniconda-version: 'latest'
-            mamba-version: '*'
-            channels: conda-forge
-            channel-priority: true
-            auto-update-conda: false
-            auto-activate-base: false
-            environment-file: ${{ matrix.environment-file }}
-            activate-environment: test
-            use-only-tar-bz2: true
-       - run: conda info --all
-       - run: conda list
-       - run: conda config --show-sources
-       - run: conda config --show
-       - run: pip install -e . --no-deps --force-reinstall	
-       - name: Pytest
-         run: py.test -v tobler --cov=tobler --cov-report=xml
-       - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
-         uses: codecov/codecov-action@v1
-         with:
-           token: ${{ secrets.CODECOV_TOKEN }}
-           file: ./coverage.xml
-           name: tobler-codecov
+jobs:
+  unittests:
+    name: CI (${{ matrix.os }}-${{ matrix.environment-file }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 90
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        environment-file: [.ci/37.yml, .ci/38.yml, .ci/39.yml]
+        experimental: [false]
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles(matrix.environment-file) }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: "latest"
+          mamba-version: "*"
+          channels: conda-forge
+          channel-priority: true
+          auto-update-conda: false
+          auto-activate-base: false
+          environment-file: ${{ matrix.environment-file }}
+          activate-environment: test
+          use-only-tar-bz2: true
+      - run: conda info --all
+      - run: conda list
+      - run: conda config --show-sources
+      - run: conda config --show
+      - run: pip install -e . --no-deps --force-reinstall
+      - name: Pytest
+        run: py.test -v tobler --cov=tobler --cov-report=xml
+      - name: codecov (${{ matrix.os }}, ${{ matrix.environment-file }})
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          name: tobler-codecov

--- a/tobler/tests/test_pycno.py
+++ b/tobler/tests/test_pycno.py
@@ -21,11 +21,6 @@ def datasets():
 def test_pycno_interpolate():
     sac1, sac2 = datasets()
     pyc = pycno_interpolate(
-        source_df=sac1,
-        target_df=sac2,
-        variables=["TOT_POP"],
-        cellsize=500
+        source_df=sac1, target_df=sac2, variables=["TOT_POP"], cellsize=500
     )
-    assert_almost_equal(pyc.TOT_POP.sum(), 1794618.503, decimal=3)
-
-
+    assert_almost_equal(pyc.TOT_POP.sum(), 1794618.503, decimal=1)


### PR DESCRIPTION
We should have scheduled tests running to catch potential issues with new versions sooner than we do any PR.