### PR TITLE
REF: remove explode from h3fy

### DIFF
--- a/tobler/util/util.py
+++ b/tobler/util/util.py
@@ -147,8 +147,9 @@ def h3fy(source, resolution=6, clip=False, return_geoms=True):
     """
     # h3 hexes only work on polygons, not multipolygons
     if source.crs is None:
-        raise ValueError('source geodataframe must have a valid CRS set before using this function')
-    source = source.explode()
+        raise ValueError(
+            "source geodataframe must have a valid CRS set before using this function"
+        )
 
     orig_crs = source.crs
 
@@ -173,7 +174,6 @@ def h3fy(source, resolution=6, clip=False, return_geoms=True):
 
     if return_geoms and not hexagons.crs.equals(orig_crs):
         hexagons = hexagons.to_crs(orig_crs)
-
 
     return hexagons
 


### PR DESCRIPTION
The latest geopandas is raising a warning in `explode` about the future change of the behaviour of an index. I wanted to add a keyword to silence it but then I realised that the `explode` is actually not needed here. We do the `unary_union` and the rest doesn't care about the multipolygons in the original input. So I removed it.