### PR TITLE
REF: move from pygeos to shapely 2

### DIFF
--- a/.ci/37.yml
+++ b/.ci/37.yml
@@ -22,7 +22,6 @@ dependencies:
   - pytest-cov
   - twine
   - pip
-  - pygeos
   - h3-py
   - joblib
   - astropy

--- a/.ci/38.yml
+++ b/.ci/38.yml
@@ -22,7 +22,6 @@ dependencies:
   - pytest-cov
   - twine
   - pip
-  - pygeos
   - h3-py
   - joblib
   - astropy

--- a/.ci/39.yml
+++ b/.ci/39.yml
@@ -20,7 +20,6 @@ dependencies:
   - pytest-cov
   - twine
   - pip
-  - pygeos
   - h3-py
   - mapclassify
   - descartes

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 # PySAL `tobler`
 
-`tobler` is a python package for areal interpolation, dasymetric mapping, change of support, and small area estimation. It provides a suite of tools with a simple interface for transferring data from one polygonal representation to another. Common examples include standardizing census data from different time periods to a single representation (i.e. to overcome boundary changes in successive years), or the conversion of data collected at different spatial scales into shared units of analysis (e.g. converting zip code and neighborhood data into a regular grid). `tobler` is part of the [PySAL](https://pysal.org) family of packages for spatial data science and provides highly performant implementations of basic and advanced interpolation methods, leveraging [`pygeos`](https://pygeos.readthedocs.io/en/latest/) to optimize for multicore architecture. The package name is an homage to the legendary quantitative geographer [Waldo Tobler](https://en.wikipedia.org/wiki/Waldo_R._Tobler), a pioneer in geographic interpolation methods, spatial analysis, and computational social science.
+`tobler` is a python package for areal interpolation, dasymetric mapping, change of support, and small area estimation. It provides a suite of tools with a simple interface for transferring data from one polygonal representation to another. Common examples include standardizing census data from different time periods to a single representation (i.e. to overcome boundary changes in successive years), or the conversion of data collected at different spatial scales into shared units of analysis (e.g. converting zip code and neighborhood data into a regular grid). `tobler` is part of the [PySAL](https://pysal.org) family of packages for spatial data science and provides highly performant implementations of basic and advanced interpolation methods, leveraging [`shapely`](https://shapely.readthedocs.io/en/latest/) to optimize for multicore architecture. The package name is an homage to the legendary quantitative geographer [Waldo Tobler](https://en.wikipedia.org/wiki/Waldo_R._Tobler), a pioneer in geographic interpolation methods, spatial analysis, and computational social science.
 
 ![DC tracts to hexgrid](docs/_static/images/notebooks_census_to_hexgrid_25_1.png)
 
@@ -49,7 +49,7 @@ Model-based interpolation uses [spatial] statistical models to estimate a relati
 
 ```bash
 $ conda env create -f environment.yml
-$ conda activate tobler 
+$ conda activate tobler
 $ python setup.py develop
 ```
 
@@ -65,7 +65,7 @@ The project is licensed under the [BSD license](https://github.com/pysal/tobler/
 
 ## Funding
 
-<img src="docs/figs/nsf_logo.jpg" width="50"> 
+<img src="docs/figs/nsf_logo.jpg" width="50">
 
 Award #1733705 [Neighborhoods in Space-Time Contexts](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1733705&HistoricalAwards=false)
 

--- a/docs/notebooks/area_interpolate_perf.ipynb
+++ b/docs/notebooks/area_interpolate_perf.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,6 @@ dependencies:
   - libpysal
   - tqdm
   - pip
-  - pygeos
-  - mapclassify 
+  - mapclassify
   - descartes
   - joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ statsmodels
 rasterstats
 libpysal
 tqdm
-pygeos
 joblib
+shapely>=2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ rasterstats
 libpysal
 tqdm
 joblib
-shapely>=2

--- a/tobler/area_weighted/area_interpolate.py
+++ b/tobler/area_weighted/area_interpolate.py
@@ -43,15 +43,13 @@ def _chunk_polys(id_pairs, geoms_left, geoms_right, n_jobs):
     chunk_size = id_pairs.shape[0] // n_jobs + 1
     for i in range(n_jobs):
         start = i * chunk_size
-        chunk1 = geoms_left.values.data[id_pairs[start : start + chunk_size, 0]]
-        chunk2 = geoms_right.values.data[id_pairs[start : start + chunk_size, 1]]
+        chunk1 = geoms_left.array[id_pairs[start : start + chunk_size, 0]]
+        chunk2 = geoms_right.array[id_pairs[start : start + chunk_size, 1]]
         yield chunk1, chunk2
 
 
 def _intersect_area_on_chunk(geoms1, geoms2):
-    import shapely
-
-    areas = shapely.area(shapely.intersection(geoms1, geoms2))
+    areas = geoms1.intersection(geoms2).area
     return areas
 
 
@@ -306,7 +304,6 @@ def _area_interpolate_binning(
     dfs = []
     extensive = []
     if extensive_variables:
-
         den = source_df.area.values
         if allocate_total:
             den = np.asarray(table.sum(axis=1))
@@ -330,7 +327,6 @@ def _area_interpolate_binning(
 
     intensive = []
     if intensive_variables:
-
         area = np.asarray(table.sum(axis=0))
         den = 1.0 / (area + (area == 0))
         n, k = den.shape

--- a/tobler/area_weighted/area_interpolate.py
+++ b/tobler/area_weighted/area_interpolate.py
@@ -49,9 +49,9 @@ def _chunk_polys(id_pairs, geoms_left, geoms_right, n_jobs):
 
 
 def _intersect_area_on_chunk(geoms1, geoms2):
-    import pygeos
+    import shapely
 
-    areas = pygeos.area(pygeos.intersection(geoms1, geoms2))
+    areas = shapely.area(shapely.intersection(geoms1, geoms2))
     return areas
 
 
@@ -249,8 +249,6 @@ def _area_interpolate_binning(
         [Optional. Default=1] Number of processes to run in parallel to
         generate the area allocation. If -1, this is set to the number of CPUs
         available. If `table` is passed, this is ignored.
-        NOTE: as of Jan'21 multi-core functionality requires master versions
-        of `pygeos` and `geopandas`.
     categorical_variables : list
         [Optional. Default=None] Columns in dataframes for categorical variables
 


### PR DESCRIPTION
Remove pygeos dependency and use geopandas GeometryArray logic instead. Compatible with both pygeos and shapely 2.