### PR TITLE
COMPAT: geopandas 1.0 compatibility fix in h3fy

### DIFF
--- a/tobler/dasymetric/raster_tools.py
+++ b/tobler/dasymetric/raster_tools.py
@@ -17,7 +17,7 @@ from shapely.geometry import shape
 
 from ..util.util import _check_presence_of_crs
 
-GPD_10 = Version(gpd.__version__) >= Version("0.99.0")
+GPD_10 = Version(gpd.__version__) >= Version("1.0.0dev")
 
 
 def _chunk_dfs(geoms_to_chunk, n_jobs):

--- a/tobler/tests/test_area_interpolators.py
+++ b/tobler/tests/test_area_interpolators.py
@@ -84,6 +84,7 @@ def test_area_interpolate_categorical():
     assert_almost_equal(area.animal_capybara.sum(), 20, decimal=0)
 
 
+@pytest.mark.xfail(reason="dask_geopandas is broken with dask-expr backend")
 def test_area_interpolate_categorical_dask():
     sac1, sac2 = datasets()
     sac1["animal"] = sac1["animal"].astype("category")

--- a/tobler/util/util.py
+++ b/tobler/util/util.py
@@ -9,7 +9,7 @@ import shapely
 from packaging.version import Version
 from shapely.geometry import Polygon
 
-GPD_10 = Version(geopandas.__version__) >= Version("0.99.0")
+GPD_10 = Version(geopandas.__version__) >= Version("1.0.0dev")
 
 
 def circumradius(resolution):

--- a/tobler/util/util.py
+++ b/tobler/util/util.py
@@ -208,6 +208,8 @@ def _to_hex(source, resolution=6, return_geoms=True, buffer=True):
         lambda hex_id: Polygon(h3.h3_to_geo_boundary(hex_id, geo_json=True)),
     )
 
-    hexs = geopandas.GeoDataFrame(hexids, geometry=polys, crs=4326).set_index("hex_id")
+    hexs = geopandas.GeoDataFrame(hexids, geometry=polys.values, crs=4326).set_index(
+        "hex_id"
+    )
 
     return hexs

--- a/tobler/util/util.py
+++ b/tobler/util/util.py
@@ -6,7 +6,10 @@ import geopandas
 import numpy as np
 import pandas
 import shapely
+from packaging.version import Version
 from shapely.geometry import Polygon
+
+GPD_10 = Version(geopandas.__version__) >= Version("0.99.0")
 
 
 def circumradius(resolution):
@@ -139,7 +142,10 @@ def h3fy(source, resolution=6, clip=False, buffer=False, return_geoms=True):
         else:
             source = source.to_crs(4326)
 
-    source_unary = shapely.force_2d(source.unary_union)
+    if GPD_10:
+        source_unary = shapely.force_2d(source.union_all())
+    else:
+        source_unary = shapely.force_2d(source.unary_union)
 
     if type(source_unary) == Polygon:
         hexagons = _to_hex(


### PR DESCRIPTION
GeoPandas now preserves the geometry column name if it has one. As a result, we end up with two columns called `hex_id` in the first step and a geometry assigned as an index in the second.

Fixed.

@knaaptime @jGaboardi we shall expand CI to test against nightly here. I caught it coincidentally when testing my teaching material against 1.0 alpha. 

Also, this will need a patch release fairly soon.