### PR TITLE
CI: include dev env in CI matrix

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,5 +1,5 @@
  name: Continuous Integration
- 
+
  on:
    push:
      branches:
@@ -28,6 +28,7 @@
             ci/310.yml,
             ci/311.yml,
             ci/312.yml,
+            ci/312-dev.yml,
          ]
          include:
            - environment-file: ci/312.yml
@@ -47,7 +48,7 @@
          uses: actions/checkout@v4
          with:
            fetch-depth: 0 # Fetch all history for all branches and tags.
-       
+
        - name: setup micromamba
          uses: mamba-org/setup-micromamba@v1
          with:
@@ -58,13 +59,13 @@
          run: |
            micromamba info
            micromamba list
-       
+
        - name: spatial versions
          run: 'python -c "import geopandas; geopandas.show_versions();"'
 
        - name: install package
          run: 'pip install . --no-deps'
-       
+
        - name: run tests
          run: |
            pytest tobler \
@@ -76,7 +77,7 @@
            --cov-append \
            --cov-report term-missing \
            --cov-report xml
-       
+
        - name: codecov
          uses: codecov/codecov-action@v3
          with:

--- a/ci/312-dev.yml
+++ b/ci/312-dev.yml
@@ -1,0 +1,39 @@
+name: test
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - dask
+  - dask-geopandas
+  - numpy
+  - pandas
+  - rasterio
+  - rasterstats
+  - statsmodels
+  - scipy
+  - libpysal
+  - tqdm
+  - codecov
+  - pytest-xdist
+  - coverage
+  - pytest
+  - pytest-mpl
+  - pytest-cov
+  - twine
+  - h3-py
+  - mapclassify
+  - sphinx>=1.4.3
+  - sphinxcontrib-bibtex==1.0.0
+  - sphinx_bootstrap_theme
+  - numpydoc
+  - nbsphinx
+  - joblib
+  - astropy
+  - pip
+  - pip:
+      # dev versions of packages
+      - --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple
+      - scikit-learn
+      - scipy
+      - git+https://github.com/geopandas/geopandas.git@main
+      - shapely


### PR DESCRIPTION
I think that the dev failures we're seeing in libpysal are actually coming from here. And we should test against dev versions anyway.