### PR TITLE
CI: fetch examples ahead of time

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -66,6 +66,14 @@
        - name: install package
          run: 'pip install . --no-deps'
 
+       - name: Download test files
+         run: |
+           python -c '
+           import libpysal
+
+           libpysal.examples.fetch_all()
+           '
+
        - name: run tests
          run: |
            pytest tobler \


### PR DESCRIPTION
Copied from libpysal and should resolve CI issue of [this](https://github.com/pysal/tobler/actions/runs/12820486430/job/35750122085) sort.