### PR TITLE
CI: pull dask-geopandas dev in dev env

### DIFF
--- a/ci/313-dev.yml
+++ b/ci/313-dev.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - python=3.13
   - dask
-  - dask-geopandas
   - numpy
   - pandas
   - rasterio
@@ -37,4 +36,5 @@ dependencies:
       - scikit-learn
       - scipy
       - git+https://github.com/geopandas/geopandas.git@main
+      - git+https://github.com/geopandas/dask-geopandas.git@main
       - shapely


### PR DESCRIPTION
I merged the fix for our errors over in dask-geopandas but we need to actually use it here to get the CI green again.